### PR TITLE
feat: email API v2 com templates dinâmicos no banco

### DIFF
--- a/EMAIL_API_V2.md
+++ b/EMAIL_API_V2.md
@@ -1,0 +1,270 @@
+# Email API v2
+
+API de envio de emails com templates dinâmicos armazenados no banco de dados.
+Ao contrário da v1, nenhum redeploy é necessário para adicionar suporte a um novo sistema — basta registrar o template via API e começar a enviar.
+
+---
+
+## Base URL
+
+```
+https://<host>/v2/email
+```
+
+---
+
+## Fluxo de integração
+
+```
+1. Registrar template  →  POST /v2/email/templates
+2. Enviar emails       →  POST /v2/email/send
+```
+
+---
+
+## Endpoints
+
+### 1. Registrar template
+
+```
+POST /v2/email/templates
+Content-Type: application/json
+```
+
+**Body**
+
+| Campo          | Tipo   | Obrigatório | Descrição                                                     |
+|----------------|--------|-------------|---------------------------------------------------------------|
+| `slug`         | string | sim         | Identificador único do template (ex: `"confirmacao-cadastro"`) |
+| `name`         | string | não         | Nome legível do template                                      |
+| `fromEmail`    | string | não         | Endereço remetente. Padrão: `info@jeanconsultoria.com`        |
+| `htmlTemplate` | string | sim         | HTML completo do email com variáveis no formato `{{.nomeVar}}` |
+
+**Exemplo**
+
+```json
+{
+  "slug": "confirmacao-cadastro",
+  "name": "Confirmação de Cadastro",
+  "fromEmail": "noreply@meuapp.com",
+  "htmlTemplate": "<html><body><h1>Olá, {{.username}}!</h1><p>{{.mensagem}}</p><a href='{{.link}}'>Confirmar</a></body></html>"
+}
+```
+
+**Resposta — 201 Created**
+
+```json
+{
+  "status": "created",
+  "message": "template created successfully",
+  "slug": "confirmacao-cadastro"
+}
+```
+
+---
+
+### 2. Enviar email
+
+```
+POST /v2/email/send
+Content-Type: application/json
+```
+
+**Body**
+
+| Campo          | Tipo              | Obrigatório | Descrição                                             |
+|----------------|-------------------|-------------|-------------------------------------------------------|
+| `templateSlug` | string            | sim         | Slug do template cadastrado                           |
+| `to`           | string            | sim         | Endereço de email do destinatário                     |
+| `subject`      | string            | sim         | Assunto do email                                      |
+| `variables`    | map[string]string | não         | Valores para substituir as variáveis do template HTML |
+
+**Exemplo**
+
+```json
+{
+  "templateSlug": "confirmacao-cadastro",
+  "to": "usuario@email.com",
+  "subject": "Confirme seu cadastro",
+  "variables": {
+    "username": "Maria",
+    "mensagem": "Seja bem-vinda à plataforma!",
+    "link": "https://meuapp.com/confirmar?token=abc123"
+  }
+}
+```
+
+**Resposta — 200 OK**
+
+```json
+{
+  "status": "pending",
+  "message": "email queued successfully"
+}
+```
+
+O envio é assíncrono — a resposta confirma que o email foi enfileirado, não que foi entregue.
+
+---
+
+### 3. Listar templates
+
+```
+GET /v2/email/templates
+```
+
+**Resposta — 200 OK**
+
+```json
+[
+  {
+    "slug": "confirmacao-cadastro",
+    "name": "Confirmação de Cadastro",
+    "fromEmail": "noreply@meuapp.com",
+    "htmlTemplate": "...",
+    "createdAt": "2026-04-20T10:00:00Z",
+    "updatedAt": "2026-04-20T10:00:00Z"
+  }
+]
+```
+
+---
+
+### 4. Buscar template por slug
+
+```
+GET /v2/email/templates/{slug}
+```
+
+**Resposta — 200 OK**
+
+```json
+{
+  "slug": "confirmacao-cadastro",
+  "name": "Confirmação de Cadastro",
+  "fromEmail": "noreply@meuapp.com",
+  "htmlTemplate": "...",
+  "createdAt": "2026-04-20T10:00:00Z",
+  "updatedAt": "2026-04-20T10:00:00Z"
+}
+```
+
+**Resposta — 404 Not Found** quando o slug não existe.
+
+---
+
+### 5. Atualizar template
+
+```
+PUT /v2/email/templates/{slug}
+Content-Type: application/json
+```
+
+**Body** — mesmos campos do registro (exceto `slug`, que vem na URL)
+
+```json
+{
+  "name": "Confirmação de Cadastro v2",
+  "fromEmail": "noreply@meuapp.com",
+  "htmlTemplate": "<html><body><h1>Olá {{.username}}, tudo bem?</h1></body></html>"
+}
+```
+
+**Resposta — 200 OK**
+
+```json
+{
+  "status": "updated",
+  "message": "template updated successfully"
+}
+```
+
+---
+
+### 6. Deletar template
+
+```
+DELETE /v2/email/templates/{slug}
+```
+
+**Resposta — 204 No Content**
+
+---
+
+## Sintaxe de variáveis no template
+
+Os templates utilizam a sintaxe nativa do Go (`html/template`).
+
+| Sintaxe              | Descrição                                    |
+|----------------------|----------------------------------------------|
+| `{{.nomeVar}}`       | Substitui pelo valor da variável             |
+| `{{if .nomeVar}}...{{end}}` | Bloco condicional (renderiza se não vazio) |
+| `{{range .lista}}...{{end}}` | Iteração sobre lista                  |
+
+**Exemplo com condicional:**
+
+```html
+<p>Olá, {{.username}}!</p>
+{{if .link}}
+  <a href="{{.link}}">Clique aqui</a>
+{{end}}
+```
+
+> **Atenção:** se o HTML do template contiver `{{` fora de variáveis (ex: JavaScript inline), escape com `{{ "{{" }}`.
+
+---
+
+## Códigos de resposta
+
+| Código | Situação                                       |
+|--------|------------------------------------------------|
+| 200    | Sucesso                                        |
+| 201    | Template criado                                |
+| 204    | Template deletado                              |
+| 400    | Dados inválidos ou template não encontrado     |
+| 405    | Método HTTP não permitido                      |
+| 500    | Erro interno                                   |
+
+---
+
+## Exemplo completo: nova integração
+
+### Passo 1 — Registrar o template uma única vez
+
+```bash
+curl -X POST https://<host>/v2/email/templates \
+  -H "Content-Type: application/json" \
+  -d '{
+    "slug": "boas-vindas-meuapp",
+    "name": "Boas-vindas MeuApp",
+    "fromEmail": "noreply@meuapp.com",
+    "htmlTemplate": "<html><body><h2>Bem-vindo, {{.nome}}!</h2><p>{{.descricao}}</p></body></html>"
+  }'
+```
+
+### Passo 2 — Enviar quando necessário
+
+```bash
+curl -X POST https://<host>/v2/email/send \
+  -H "Content-Type: application/json" \
+  -d '{
+    "templateSlug": "boas-vindas-meuapp",
+    "to": "novo@usuario.com",
+    "subject": "Bem-vindo ao MeuApp!",
+    "variables": {
+      "nome": "Carlos",
+      "descricao": "Sua conta foi criada com sucesso."
+    }
+  }'
+```
+
+---
+
+## Diferenças em relação à v1
+
+| Aspecto            | v1 (`/email`)                  | v2 (`/v2/email`)                         |
+|--------------------|-------------------------------|------------------------------------------|
+| Templates          | Hardcoded no código Go         | Armazenados no banco, gerenciáveis via API |
+| Variáveis          | Struct tipada (`customBodyProps`) | `map[string]string` livre               |
+| Nova integração    | Requer redeploy                | Apenas um POST para registrar o template |
+| Compatibilidade    | Mantida, sem alterações        | —                                        |

--- a/api/email_v2.go
+++ b/api/email_v2.go
@@ -1,0 +1,138 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Jean1dev/communication-service/internal/dto"
+	"github.com/Jean1dev/communication-service/internal/infra/database"
+	"github.com/Jean1dev/communication-service/internal/services"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func SendEmailV2Handler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var input dto.SendEmailV2Dto
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if err := services.SendEmailV2(input); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	db := database.GetDB()
+	emailEntity := struct {
+		To        string             `json:"to"`
+		CreatedAt primitive.DateTime `bson:"createdAt" json:"createdAt"`
+	}{
+		To:        input.To,
+		CreatedAt: primitive.NewDateTimeFromTime(time.Now()),
+	}
+	go db.Insert(emailEntity, email_collection)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":  "pending",
+		"message": "email queued successfully",
+	})
+}
+
+func EmailTemplatesV2Handler(w http.ResponseWriter, r *http.Request) {
+	slug := strings.TrimPrefix(r.URL.Path, "/v2/email/templates")
+	slug = strings.TrimPrefix(slug, "/")
+
+	switch {
+	case slug == "" && r.Method == http.MethodGet:
+		listTemplates(w, r)
+	case slug == "" && r.Method == http.MethodPost:
+		createTemplate(w, r)
+	case slug != "" && r.Method == http.MethodGet:
+		getTemplate(w, r, slug)
+	case slug != "" && r.Method == http.MethodPut:
+		updateTemplate(w, r, slug)
+	case slug != "" && r.Method == http.MethodDelete:
+		deleteTemplate(w, r, slug)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func createTemplate(w http.ResponseWriter, r *http.Request) {
+	var t dto.EmailTemplateDto
+	if err := json.NewDecoder(r.Body).Decode(&t); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if err := services.CreateEmailTemplate(t); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":  "created",
+		"message": "template created successfully",
+		"slug":    t.Slug,
+	})
+}
+
+func listTemplates(w http.ResponseWriter, r *http.Request) {
+	templates, err := services.ListEmailTemplates()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(templates)
+}
+
+func getTemplate(w http.ResponseWriter, r *http.Request, slug string) {
+	t, err := services.GetEmailTemplate(slug)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(t)
+}
+
+func updateTemplate(w http.ResponseWriter, r *http.Request, slug string) {
+	var t dto.EmailTemplateDto
+	if err := json.NewDecoder(r.Body).Decode(&t); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if err := services.UpdateEmailTemplate(slug, t); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":  "updated",
+		"message": "template updated successfully",
+	})
+}
+
+func deleteTemplate(w http.ResponseWriter, r *http.Request, slug string) {
+	if err := services.DeleteEmailTemplate(slug); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/dto/email_template_dto.go
+++ b/internal/dto/email_template_dto.go
@@ -1,0 +1,35 @@
+package dto
+
+import (
+	"errors"
+	"time"
+)
+
+type EmailTemplateDto struct {
+	Slug         string    `json:"slug" bson:"slug"`
+	Name         string    `json:"name" bson:"name"`
+	FromEmail    string    `json:"fromEmail" bson:"fromEmail"`
+	HtmlTemplate string    `json:"htmlTemplate" bson:"htmlTemplate"`
+	CreatedAt    time.Time `json:"createdAt" bson:"createdAt"`
+	UpdatedAt    time.Time `json:"updatedAt" bson:"updatedAt"`
+}
+
+type SendEmailV2Dto struct {
+	TemplateSlug string            `json:"templateSlug"`
+	To           string            `json:"to"`
+	Subject      string            `json:"subject"`
+	Variables    map[string]string `json:"variables"`
+}
+
+func (s *SendEmailV2Dto) Validate() error {
+	if s.To == "" {
+		return errors.New("to cannot be empty")
+	}
+	if s.Subject == "" {
+		return errors.New("subject cannot be empty")
+	}
+	if s.TemplateSlug == "" {
+		return errors.New("templateSlug cannot be empty")
+	}
+	return nil
+}

--- a/internal/infra/server.go
+++ b/internal/infra/server.go
@@ -37,6 +37,10 @@ func setupAPI() {
 	}
 
 	sentryHandler := sentryhttp.New(sentryhttp.Options{})
+	http.HandleFunc("/v2/email/send", configs.CORSMiddleware(sentryHandler.HandleFunc(api.SendEmailV2Handler)))
+	http.HandleFunc("/v2/email/templates", configs.CORSMiddleware(sentryHandler.HandleFunc(api.EmailTemplatesV2Handler)))
+	http.HandleFunc("/v2/email/templates/", configs.CORSMiddleware(sentryHandler.HandleFunc(api.EmailTemplatesV2Handler)))
+
 	http.HandleFunc("/email", configs.CORSMiddleware(sentryHandler.HandleFunc(api.EmailHandler)))
 	http.HandleFunc("/email-stats", configs.CORSMiddleware(sentryHandler.HandleFunc(api.EmailEstatisticasHandler)))
 	http.HandleFunc("/email/meconectei", configs.CORSMiddleware(sentryHandler.HandleFunc(api.MeConecteiEmailHandler)))

--- a/internal/services/email_template_service.go
+++ b/internal/services/email_template_service.go
@@ -1,0 +1,119 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"html/template"
+	"time"
+
+	"github.com/Jean1dev/communication-service/internal/dto"
+	"github.com/Jean1dev/communication-service/internal/infra/database"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+const emailTemplatesCollection = "email_templates_v2"
+
+func CreateEmailTemplate(t dto.EmailTemplateDto) error {
+	if t.Slug == "" {
+		return errors.New("slug cannot be empty")
+	}
+	if t.HtmlTemplate == "" {
+		return errors.New("htmlTemplate cannot be empty")
+	}
+
+	db := database.GetDB()
+	t.CreatedAt = time.Now()
+	t.UpdatedAt = time.Now()
+	return db.Insert(t, emailTemplatesCollection)
+}
+
+func GetEmailTemplate(slug string) (*dto.EmailTemplateDto, error) {
+	db := database.GetDB()
+	filter := bson.D{{Key: "slug", Value: slug}}
+	err, result := db.FindOne(emailTemplatesCollection, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	var tmpl dto.EmailTemplateDto
+	if err := result.Decode(&tmpl); err != nil {
+		return nil, errors.New("template not found")
+	}
+	return &tmpl, nil
+}
+
+func ListEmailTemplates() ([]dto.EmailTemplateDto, error) {
+	db := database.GetDB()
+	err, cursor := db.FindAll(emailTemplatesCollection, bson.D{}, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var templates []dto.EmailTemplateDto
+	if err := cursor.All(context.TODO(), &templates); err != nil {
+		return nil, err
+	}
+	return templates, nil
+}
+
+func UpdateEmailTemplate(slug string, updated dto.EmailTemplateDto) error {
+	db := database.GetDB()
+	filter := bson.D{{Key: "slug", Value: slug}}
+	update := bson.D{{Key: "$set", Value: bson.D{
+		{Key: "name", Value: updated.Name},
+		{Key: "fromEmail", Value: updated.FromEmail},
+		{Key: "htmlTemplate", Value: updated.HtmlTemplate},
+		{Key: "updatedAt", Value: time.Now()},
+	}}}
+	return db.UpdateOne(emailTemplatesCollection, filter, update)
+}
+
+func DeleteEmailTemplate(slug string) error {
+	db := database.GetDB()
+	filter := bson.D{{Key: "slug", Value: slug}}
+	_, err := db.DeleteOne(emailTemplatesCollection, filter)
+	return err
+}
+
+func SendEmailV2(input dto.SendEmailV2Dto) error {
+	if err := input.Validate(); err != nil {
+		return err
+	}
+
+	tmpl, err := GetEmailTemplate(input.TemplateSlug)
+	if err != nil {
+		return err
+	}
+
+	html, err := renderEmailTemplate(tmpl.HtmlTemplate, input.Variables)
+	if err != nil {
+		return err
+	}
+
+	fromEmail := tmpl.FromEmail
+	if fromEmail == "" {
+		fromEmail = "info@jeanconsultoria.com"
+	}
+
+	AsyncSendRaw(input.Subject, input.To, html, fromEmail, "")
+	return nil
+}
+
+func renderEmailTemplate(htmlTemplate string, variables map[string]string) (string, error) {
+	tmpl, err := template.New("email").Parse(htmlTemplate)
+	if err != nil {
+		return "", err
+	}
+
+	data := make(map[string]interface{}, len(variables))
+	for k, v := range variables {
+		data[k] = v
+	}
+
+	var result bytes.Buffer
+	if err := tmpl.Execute(&result, data); err != nil {
+		return "", err
+	}
+	return result.String(), nil
+}

--- a/internal/services/mailer.go
+++ b/internal/services/mailer.go
@@ -177,6 +177,14 @@ func sendWithSES(subject, recipient, htmlTemplate, attachment, source string) {
 	}
 }
 
+func AsyncSendRaw(subject, recipient, htmlBody, fromEmail, attachmentLink string) {
+	if recipient == "jeanlucafp@gmail.com" {
+		go sendWithMailgun(subject, recipient, htmlBody, attachmentLink)
+	} else {
+		go sendWithSES(subject, recipient, htmlBody, attachmentLink, fromEmail)
+	}
+}
+
 func AsyncSend(input dto.MailSenderInputDto) error {
 	if err := input.Validate(); err != nil {
 		return err


### PR DESCRIPTION
## Resumo

- Adiciona API v2 de email (`/v2/email/*`) com templates armazenados no MongoDB
- Novos sistemas se integram apenas registrando um template via POST — sem necessidade de redeploy
- Contratos da v1 (`/email`, `/email/meconectei`) mantidos intactos

## Arquivos adicionados

- `internal/dto/email_template_dto.go` — DTOs `EmailTemplateDto` e `SendEmailV2Dto`
- `internal/services/email_template_service.go` — CRUD de templates + renderização + envio
- `api/email_v2.go` — handlers HTTP para todos os endpoints v2
- `EMAIL_API_V2.md` — documentação completa para integração de novos sistemas

## Arquivos modificados

- `internal/services/mailer.go` — adicionado `AsyncSendRaw` (envia HTML já renderizado, sem struct tipada)
- `internal/infra/server.go` — registro das novas rotas v2

## Endpoints v2

| Método | Rota | Descrição |
|--------|------|-----------|
| `POST` | `/v2/email/templates` | Registra novo template |
| `GET` | `/v2/email/templates` | Lista templates |
| `GET` | `/v2/email/templates/{slug}` | Busca template por slug |
| `PUT` | `/v2/email/templates/{slug}` | Atualiza template |
| `DELETE` | `/v2/email/templates/{slug}` | Remove template |
| `POST` | `/v2/email/send` | Envia email via slug + variáveis |

## Plano de testes

- [ ] Registrar template com `POST /v2/email/templates`
- [ ] Listar templates com `GET /v2/email/templates`
- [ ] Enviar email com `POST /v2/email/send` passando variáveis
- [ ] Verificar que `/email` e `/email/meconectei` continuam funcionando normalmente
- [ ] Testar variáveis inexistentes no template (deve renderizar vazio, não erro)

https://claude.ai/code/session_01FD1AhinQymGMuwdkeeaJUM